### PR TITLE
Add Onepilot to Remote Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Codex CLI team members and frequent contributors:
 - [ShunmeiCho/cc-clip](https://github.com/ShunmeiCho/cc-clip) - Paste images into remote Claude Code and Codex CLI over SSH. Clipboard bridging for macOS and Windows. ![GitHub stars](https://img.shields.io/github/stars/ShunmeiCho/cc-clip?style=flat-square)
 - [chuvadenovembro/script-to-use-codex-cli-on-remote-server](https://github.com/chuvadenovembro/script-to-use-codex-cli-on-remote-server-without-visual-environment) - Headless server setup guide with auth workarounds. ![GitHub stars](https://img.shields.io/github/stars/chuvadenovembro/script-to-use-codex-cli-on-remote-server-without-visual-environment?style=flat-square)
 - [Emanuele-web04/remodex](https://github.com/Emanuele-web04/remodex) - Local-first iOS app + Mac bridge for remote Codex control. Encrypted sessions, Git integration, App Store available. ![GitHub stars](https://img.shields.io/github/stars/Emanuele-web04/remodex?style=flat-square)
+- [Onepilot](https://onepilotapp.com) - Native iOS SSH terminal for running Codex CLI on remote servers. Full PTY, GitHub integration, localhost forwarding, live file editing, and one-click AI agent deployment via OpenClaw. Free tier, [App Store](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919).
 
 ---
 


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) to the Remote Access section.

Onepilot is a native iOS SSH terminal for running Codex CLI (and Claude Code) on remote servers. It provides full PTY terminal access, GitHub integration, localhost forwarding, live file editing, and one-click AI agent deployment via OpenClaw.

- Free tier available
- [App Store link](https://apps.apple.com/app/onepilot-ai-terminal/id6743826919)
- Directly related to Codex CLI — it's a mobile client for accessing Codex on remote machines
- Actively maintained

Fits alongside existing Remote Access entries like remodex (iOS app) and ccpocket (mobile web UI).