### PR TITLE
Add SwarmVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [callstackincubator/agent-skills](https://github.com/callstackincubator/agent-skills) - Agent-optimized React Native skills by Callstack: best practices, optimization, upgrade workflows. ![GitHub stars](https://img.shields.io/github/stars/callstackincubator/agent-skills?style=flat-square)
 - [Bhanunamikaze/Agentic-SEO-Skill](https://github.com/Bhanunamikaze/Agentic-SEO-Skill) - LLM-first SEO analysis with 16 sub-skills, 10 specialist agents, and 33 utility scripts. ![GitHub stars](https://img.shields.io/github/stars/Bhanunamikaze/Agentic-SEO-Skill?style=flat-square)
 - [Gitmaxd/deepagents-cli-codex-skill](https://github.com/Gitmaxd/deepagents-cli-codex-skill) - Deep Agents CLI skill - scaffolds Codex skills and launches production subagent pipelines. ![GitHub stars](https://img.shields.io/github/stars/Gitmaxd/deepagents-cli-codex-skill?style=flat-square)
+- [swarmclawai/swarmvault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge base compiler. Turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. Ships a bundled skill with graph-query-first conventions and an MCP server. Works with Codex CLI, Claude Code, and OpenCode. ![GitHub stars](https://img.shields.io/github/stars/swarmclawai/swarmvault?style=flat-square)
 
 ### Skills Management
 


### PR DESCRIPTION
Adding SwarmVault to the Specialized Skills section.

SwarmVault is a local-first RAG knowledge base compiler. It turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. The bundled skill ships in SKILL.md format (schema-first, graph-query-first conventions) and installs into `~/.codex/skills/`. An MCP server is also included, so it works with Codex CLI, Claude Code, and OpenCode out of the box. MIT licensed, published on npm as `@swarmvaultai/cli`, actively maintained.

- https://github.com/swarmclawai/swarmvault
- https://swarmvault.ai

License: MIT