### PR TITLE
Add vara-skills to Domain-Specific Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [aklofas/kicad-happy](https://github.com/aklofas/kicad-happy) - KiCad PCB design assistant. Proof that skills can go deep into niche domains. ![GitHub stars](https://img.shields.io/github/stars/aklofas/kicad-happy?style=flat-square)
 - [qtzx06/yolodex](https://github.com/qtzx06/yolodex) - Computer vision / YOLO model training workflow. ![GitHub stars](https://img.shields.io/github/stars/qtzx06/yolodex?style=flat-square)
 - [Frankieli123/grok-skill](https://github.com/Frankieli123/grok-skill) - Log analysis and pattern matching. Useful for debugging production issues. ![GitHub stars](https://img.shields.io/github/stars/Frankieli123/grok-skill?style=flat-square)
+- [gear-foundation/vara-skills](https://github.com/gear-foundation/vara-skills) - 21 skills for shipping Rust smart contracts on Vara Network with the Gear/Sails framework. Full pipeline: spec → Sails impl → gtest → on-chain deploy via `vara-wallet`. Ships as Codex install script, Claude Code plugin, and OpenClaw wrapper. ![GitHub stars](https://img.shields.io/github/stars/gear-foundation/vara-skills?style=flat-square)
 
 ## Plugins
 


### PR DESCRIPTION
Adds [vara-skills](https://github.com/gear-foundation/vara-skills) to the **Domain-Specific Skills** section (alongside `kicad-happy`, `yolodex`, and `grok-skill`).

**What it is:** 21 skills teaching Codex to build and ship Rust smart contracts on Vara Network with the Gear/Sails framework. Covers the full pipeline: spec → architecture → Rust implementation → IDL/client codegen → deterministic gtest → React frontend → event-driven indexer → on-chain deploy via `vara-wallet`.

**Codex install:**
```bash
git clone git@github.com:gear-foundation/vara-skills.git
cd vara-skills
bash scripts/install-codex-skills.sh
```

**Why it fits Domain-Specific Skills:** A niche-domain skill pack (blockchain/smart-contracts) — same profile as `kicad-happy` (PCB) or `yolodex` (CV). Works across Codex, Claude Code, and OpenClaw.

Published by Gear Foundation. MIT licensed.