### PR TITLE
Add Agent Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Codex can connect to MCP servers (as client) and expose itself as an MCP server 
 - [re-cinq/shift-log](https://github.com/re-cinq/shift-log) - Automatically saves coding agents' conversations in Git Notes. Works with Codex, Claude Code, Gemini CLI, OpenCode. ![GitHub stars](https://img.shields.io/github/stars/re-cinq/shift-log?style=flat-square)
 - [2ue/ccman](https://github.com/2ue/ccman) - Tool for managing Claude Code + Codex API + Gemini CLI + OpenCode service provider configurations. ![GitHub stars](https://img.shields.io/github/stars/2ue/ccman?style=flat-square)
 - [Dicklesworthstone/coding_agent_session_search](https://github.com/Dicklesworthstone/coding_agent_session_search) - Unified TUI and CLI to index and search local coding agent session history across 11+ providers including Codex. ![GitHub stars](https://img.shields.io/github/stars/Dicklesworthstone/coding_agent_session_search?style=flat-square)
+- [jazzyalex/agent-sessions](https://github.com/jazzyalex/agent-sessions) - Native macOS app to search, browse, and resume local Codex CLI sessions, plus Agent Cockpit for live iTerm2 orchestration across Codex, Claude Code, OpenCode, and other agents. ![GitHub stars](https://img.shields.io/github/stars/jazzyalex/agent-sessions?style=flat-square)
 
 ## Model Providers & Proxies
 


### PR DESCRIPTION
Adds Agent Sessions to the Session & Workflow Management section.

Why it fits:
- Directly supports Codex CLI session history browsing and resume workflows.
- Includes Agent Cockpit for live iTerm2 orchestration/monitoring across Codex, Claude Code, OpenCode, and other local agent sessions.
- Provides local-first search across Codex sessions alongside other coding agents.
- Includes the required GitHub stars badge in the existing list format.