### PR TITLE
Add codebase-recon-skill to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Distributable bundles combining skills + app integrations + MCP servers. Defined
 - [xmm/codex-bmad-skills](https://github.com/xmm/codex-bmad-skills) - BMAD methodology plugin - structured planning, design, and implementation workflow.
 - [regenrek/codex-1up](https://github.com/regenrek/codex-1up) - Bootstrap tool that installs Codex CLI plus curated power tools and an AGENTS.md template. Three profiles: balanced, safe, yolo. ![GitHub stars](https://img.shields.io/github/stars/regenrek/codex-1up?style=flat-square)
 - [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) - Compound Engineering plugin for Claude Code, Codex, and more. Structured multi-agent workflows. ![GitHub stars](https://img.shields.io/github/stars/EveryInc/compound-engineering-plugin?style=flat-square)
+- [yujiachen-y/codebase-recon-skill](https://github.com/yujiachen-y/codebase-recon-skill) - Codebase reconnaissance plugin — analyzes git history to surface hotspots, bug magnets, bus factor, and momentum before you read any code. Auto-scales by repo size; cross-references hotspots with bug magnets to flag high-risk files. ![GitHub stars](https://img.shields.io/github/stars/yujiachen-y/codebase-recon-skill?style=flat-square)
 
 ## Hooks
 


### PR DESCRIPTION
## Summary

Adds [yujiachen-y/codebase-recon-skill](https://github.com/yujiachen-y/codebase-recon-skill) to the **Plugins** section. It's a Codex plugin (`.codex-plugin/plugin.json`) that analyzes git history to give a fast, evidence-based read on a codebase before you open any source files — surfaces hotspots, bug magnets, bus factor, momentum, and high-risk files.

## Validation against `CONTRIBUTING.md`

- [x] **Directly related to Codex CLI** — installs as a Codex plugin via `codex plugin marketplace add`
- [x] **Actively maintained** — last commit today
- [x] **Clear, value-focused description** — names the specific signals it surfaces (hotspots / bug magnets / bus factor / momentum) rather than just "git tool"
- [x] **Star badge included** with `flat-square` style

🤖 Generated with [Claude Code](https://claude.com/claude-code)