### PR TITLE
✨ Add KubeStellar Console MCP server (kc-agent) for Kubernetes operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Codex can connect to MCP servers (as client) and expose itself as an MCP server 
 - [karad/seiro-mcp](https://github.com/karad/seiro-mcp) - MCP server and skills for autonomous build workflows for visionOS (Swift) apps using Codex CLI. ![GitHub stars](https://img.shields.io/github/stars/karad/seiro-mcp?style=flat-square)
 - [salparadi-labs/brain](https://github.com/salparadi-labs/brain) - Persistent memory MCP server for Codex sessions - stores decisions, tasks, preferences in SQLite. ![GitHub stars](https://img.shields.io/github/stars/salparadi-labs/brain?style=flat-square)
 - [vanthienha199/agent-cost-mcp](https://github.com/vanthienha199/agent-cost-mcp) - MCP server for tracking AI agent costs in real time - per-message spending, budget alerts, visual dashboard. ![GitHub stars](https://img.shields.io/github/stars/vanthienha199/agent-cost-mcp?style=flat-square)
+- [kubestellar/console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with MCP server (kc-agent) bridging kubeconfig to AI agents for cluster operations. CNCF Sandbox. ![GitHub stars](https://img.shields.io/github/stars/kubestellar/console?style=flat-square)
 
 ### Codex as MCP Server
 


### PR DESCRIPTION
## What
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Codex as MCP Client** section under MCP Servers.

## Why
KubeStellar Console provides **kc-agent**, an MCP server that bridges kubeconfig contexts to AI coding agents. This enables multi-cluster Kubernetes operations directly from Codex CLI:

- **Pod management** — list, describe, delete pods across clusters
- **Log streaming** — tail container logs from any connected cluster
- **Deployment operations** — scale, restart, rollout across edge and cloud
- **Multi-cluster** — single MCP endpoint covers all kubeconfig contexts
- **CNCF Sandbox** project, Apache-2.0 license

## Format
Follows the existing entry format with GitHub stars badge.