### PR TITLE
Add TweetClaw X Twitter skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [aklofas/kicad-happy](https://github.com/aklofas/kicad-happy) - KiCad PCB design assistant. Proof that skills can go deep into niche domains. ![GitHub stars](https://img.shields.io/github/stars/aklofas/kicad-happy?style=flat-square)
 - [qtzx06/yolodex](https://github.com/qtzx06/yolodex) - Computer vision / YOLO model training workflow. ![GitHub stars](https://img.shields.io/github/stars/qtzx06/yolodex?style=flat-square)
 - [Frankieli123/grok-skill](https://github.com/Frankieli123/grok-skill) - Log analysis and pattern matching. Useful for debugging production issues. ![GitHub stars](https://img.shields.io/github/stars/Frankieli123/grok-skill?style=flat-square)
+- [Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw) - Codex-compatible SKILL.md and OpenClaw plugin for X/Twitter automation: search tweets, post tweets and replies, export followers, monitor tweets, send direct messages, handle webhooks, and run giveaway draws through Xquik. ![GitHub stars](https://img.shields.io/github/stars/Xquik-dev/tweetclaw?style=flat-square)
 
 ## Plugins
 


### PR DESCRIPTION
## Summary
- Add TweetClaw to Domain-Specific Skills as a Codex-compatible SKILL.md and OpenClaw plugin for X/Twitter workflows.
- Highlight concrete jobs users search for: search tweets, post tweets and replies, export followers, monitor tweets, direct messages, webhooks, and giveaway draws.
- Keep the existing README entry and GitHub stars badge style.

## Validation
- Read README, CONTRIBUTING, license, repo metadata, open PRs, open issues, and duplicate search results.
- Confirmed no existing TweetClaw, Xquik, x-twitter-scraper, or @xquik/tweetclaw mention in this repo.
- Ran git diff --check.
