### PR TITLE
Add slash9494/ai-config-sync-manager to Cross-Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Tools that bridge Codex with other AI coding agents.
 - [oil-oil/codex](https://github.com/oil-oil/codex) - Claude Code skill for delegating coding tasks to Codex CLI. ![GitHub stars](https://img.shields.io/github/stars/oil-oil/codex?style=flat-square)
 - [josstei/maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) - Multi-agent orchestration platform for Gemini CLI, Claude Code, and Codex - 22 specialists, parallel subagents, persistent sessions. ![GitHub stars](https://img.shields.io/github/stars/josstei/maestro-orchestrate?style=flat-square)
 - [catlog22/Claude-Code-Workflow](https://github.com/catlog22/Claude-Code-Workflow) - JSON-driven multi-agent cadence-team development framework with intelligent CLI orchestration (Gemini/Qwen/Codex). ![GitHub stars](https://img.shields.io/github/stars/catlog22/Claude-Code-Workflow?style=flat-square)
+- [slash9494/ai-config-sync-manager](https://github.com/slash9494/ai-config-sync-manager) - Bidirectional sync between Claude Code and Codex. Compares and merges rules, agents, MCP servers, hooks, and settings with YAML round-trip safety across lenient and strict parsers. ![GitHub stars](https://img.shields.io/github/stars/slash9494/ai-config-sync-manager?style=flat-square)
 
 ## Monitoring & Analytics
 


### PR DESCRIPTION
### Resource
[slash9494/ai-config-sync-manager](https://github.com/slash9494/ai-config-sync-manager)

### Category
Cross-Agent Tools — bridges Codex CLI with Claude Code.

### What it does
Bidirectional sync between Claude Code (`~/.claude`) and Codex (`~/.codex`) configurations. Unlike one-way sync tools, it diffs both sides, then converts and merges:

- Rules (`CLAUDE.md` ↔ `AGENTS.md`)
- Agents / subagents
- MCP server configs
- Hooks
- Permissions / settings

Designed around a YAML round-trip guarantee — frontmatter survives a pass through both the lenient Claude parser and the strict Codex (YAML 1.2) parser without field loss.

### How it differs from existing entries
- **vs `lbb00/ai-rules-sync`**: covers full config space (agents, MCP, hooks, settings), not just rules files. Bidirectional, not single-source.
- **vs `Leoyang183/sync-agents-settings`**: covers more than just MCP — full config diff/merge across both directions.
- **vs general orchestrators (`josstei/maestro-orchestrate`, etc.)**: not an orchestration platform; a focused config sync utility.

### Maintenance
- Released 0.1.0 stable (npm + GitHub).
- Active development (recent commits within the past week).
- MIT licensed.
- Zero runtime dependencies (Node ESM, single-file CLI).

### Why it fits
The list already includes config-sync tools under Cross-Agent Tools. This one targets the Claude ↔ Codex direction specifically and handles a wider config surface than existing entries.