### PR TITLE
Add marmot-sh/marmot to Specialized Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [callstackincubator/agent-skills](https://github.com/callstackincubator/agent-skills) - Agent-optimized React Native skills by Callstack: best practices, optimization, upgrade workflows. ![GitHub stars](https://img.shields.io/github/stars/callstackincubator/agent-skills?style=flat-square)
 - [Bhanunamikaze/Agentic-SEO-Skill](https://github.com/Bhanunamikaze/Agentic-SEO-Skill) - LLM-first SEO analysis with 16 sub-skills, 10 specialist agents, and 33 utility scripts. ![GitHub stars](https://img.shields.io/github/stars/Bhanunamikaze/Agentic-SEO-Skill?style=flat-square)
 - [Gitmaxd/deepagents-cli-codex-skill](https://github.com/Gitmaxd/deepagents-cli-codex-skill) - Deep Agents CLI skill - scaffolds Codex skills and launches production subagent pipelines. ![GitHub stars](https://img.shields.io/github/stars/Gitmaxd/deepagents-cli-codex-skill?style=flat-square)
+- [marmot-sh/marmot](https://github.com/marmot-sh/marmot) — Codex skill that teaches the agent to call Marmot's shell-native CLI for AI, search, scraping, and data enrichment across many providers, composable via shell pipes. ![GitHub stars](https://img.shields.io/github/stars/marmot-sh/marmot?style=flat-square)
 
 ### Skills Management
 


### PR DESCRIPTION
Adds [marmot-sh/marmot](https://github.com/marmot-sh/marmot) under **Skills → Specialized Skills**.

**Codex integration is explicit, not incidental:**
- Marmot ships a Codex skill that auto-symlinks to `~/.codex/skills/marmot` on install
- Codex is named in the project README, the skill installer, and the docs
- Skill teaches Codex the Marmot verb shape so the agent composes provider calls without bespoke prompts

**What Codex users get:** a single shell-native CLI for AI generation, web search, scraping, deep research, and people/company enrichment across many providers (OpenRouter, Anthropic, OpenAI, Vercel AI Gateway, Cloudflare, Ollama; Brave, Exa, Firecrawl, Parallel, Tavily; Apollo, Hunter, PDL, etc.). Composable via shell pipes:

```bash
marmot search "openrouter pricing 2026" | marmot "give me 5 bullet highlights"
git diff | marmot --stream "commit message under 60 chars"
marmot enrich --type person --email tcook@apple.com
```

**Install:** `npx skills add https://github.com/marmot-sh/marmot --skill marmot`
**Docs:** https://marmot.sh/docs
**License:** MIT