### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Tools that bridge Codex with other AI coding agents.
 - [steipete/CodexBar](https://github.com/steipete/CodexBar) - macOS menu bar app showing usage stats for Codex, Claude, Cursor, Gemini without login. On-device parsing. ![GitHub stars](https://img.shields.io/github/stars/steipete/CodexBar?style=flat-square)
 - [ryoppippi/ccusage](https://github.com/ryoppippi/ccusage) - CLI for analyzing Codex/Claude Code usage from local JSONL files. Daily/monthly reports, cost breakdown, MCP server mode. ![GitHub stars](https://img.shields.io/github/stars/ryoppippi/ccusage?style=flat-square)
 - [junhoyeo/tokscale](https://github.com/junhoyeo/tokscale) - CLI + TUI + web dashboard tracking token usage across 16+ AI coding platforms. Rust core, contribution graphs, leaderboard. ![GitHub stars](https://img.shields.io/github/stars/junhoyeo/tokscale?style=flat-square)
+- [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local macOS companion for Codex sessions that helps developers hear progress, blockers, errors, and attention requests without reading every terminal. ![GitHub stars](https://img.shields.io/github/stars/agentfm-ai/agent-fm?style=flat-square)
 
 ## Docker & Sandboxing
 


### PR DESCRIPTION
Adds Agent FM, a local/open-source macOS app for listening to Codex and Claude Code sessions as they work.

It fits under Monitoring & Analytics because it is a companion/awareness tool for developers running Codex CLI alongside Claude Code, with Global Mix, blocker alerts, and BYOK narration.
