### PR TITLE
Add mturac/recsys-pipeline-architect (Skills · Domain-Specific Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [aklofas/kicad-happy](https://github.com/aklofas/kicad-happy) - KiCad PCB design assistant. Proof that skills can go deep into niche domains. ![GitHub stars](https://img.shields.io/github/stars/aklofas/kicad-happy?style=flat-square)
 - [qtzx06/yolodex](https://github.com/qtzx06/yolodex) - Computer vision / YOLO model training workflow. ![GitHub stars](https://img.shields.io/github/stars/qtzx06/yolodex?style=flat-square)
 - [Frankieli123/grok-skill](https://github.com/Frankieli123/grok-skill) - Log analysis and pattern matching. Useful for debugging production issues. ![GitHub stars](https://img.shields.io/github/stars/Frankieli123/grok-skill?style=flat-square)
+- [mturac/recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) - Composable recommendation, ranking, and feed pipeline architect. Six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework (pattern from xAI's open-sourced X For You algorithm). Emits runnable scaffolds for Strapi (TypeScript), Go, or Python/FastAPI. ![GitHub stars](https://img.shields.io/github/stars/mturac/recsys-pipeline-architect?style=flat-square)
 
 ## Plugins
 


### PR DESCRIPTION
Adds **[recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect)** under *Skills → Domain-Specific Skills*.

A vendor-agnostic skill (agentskills.io standard) for designing composable recommendation, ranking, and feed pipelines using the six-stage **Source → Hydrator → Filter → Scorer → Selector → SideEffect** framework popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm). MIT, independent reimplementation of the pattern.

**Codex compatibility**
- Installs to `~/.codex/skills/recsys-pipeline-architect/` (auto-discovered by Codex)
- Or via `npx skills add mturac/recsys-pipeline-architect` (also installs to Claude Code, Cursor, Gemini CLI, Cline, etc.)

**Repo highlights**
- `SKILL.md` (the skill) + 5 load-on-demand reference docs
- 3 runnable example scaffolds: Strapi v5 (TS/Jest), Go (generics), Python/FastAPI — every one green on its test suite (3/3 each)
- v0.1.0 GitHub release tagged

Inserted at the end of the existing **Domain-Specific Skills** list in the same format (with stars badge). Happy to revise or move if you'd prefer a different section.