### PR TITLE
Add agent-guard-plugins to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Distributable bundles combining skills + app integrations + MCP servers. Defined
 - [xmm/codex-bmad-skills](https://github.com/xmm/codex-bmad-skills) - BMAD methodology plugin - structured planning, design, and implementation workflow.
 - [regenrek/codex-1up](https://github.com/regenrek/codex-1up) - Bootstrap tool that installs Codex CLI plus curated power tools and an AGENTS.md template. Three profiles: balanced, safe, yolo. ![GitHub stars](https://img.shields.io/github/stars/regenrek/codex-1up?style=flat-square)
 - [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) - Compound Engineering plugin for Claude Code, Codex, and more. Structured multi-agent workflows. ![GitHub stars](https://img.shields.io/github/stars/EveryInc/compound-engineering-plugin?style=flat-square)
+- [dannyliv/agent-guard-plugins](https://github.com/dannyliv/agent-guard-plugins) - Prompt-injection guard plugin - bundled PreToolUse/PostToolUse hooks screen tool input and returned web/file content with a fine-tuned classifier before Codex acts on it. ![GitHub stars](https://img.shields.io/github/stars/dannyliv/agent-guard-plugins?style=flat-square)
 
 ## Hooks
 


### PR DESCRIPTION
## What

Adds [dannyliv/agent-guard-plugins](https://github.com/dannyliv/agent-guard-plugins) to the **Plugins** section.

## Why it belongs

Agent Guard is a prompt-injection security plugin for Codex CLI. It ships a real `.codex-plugin/plugin.json` manifest that bundles PreToolUse and PostToolUse lifecycle hooks. The hooks screen each tool call's input params and returned web/file/MCP content with a fine-tuned prompt-injection classifier before Codex acts on it, catching indirect prompt injection hidden in third-party content.

## Quality checklist

- Directly related to Codex CLI: ships a `.codex-plugin/plugin.json` plugin form and a repo-scoped `.agents/plugins/marketplace.json`; also installable via a one-line `agent-guard-codex-install` hook installer.
- Actively maintained: v0.5.0, CI green, published to PyPI.
- One-sentence description with value framing.
- GitHub star badge included (flat-square).
- Placed in the most specific category (Plugins).