### PR TITLE
Add Alfred

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Multi-agent orchestration with `.toml` definitions. Codex supports parallel fan-
 - [aannoo/hcom](https://github.com/aannoo/hcom) - Hierarchical agent communication framework. Agents delegate subtasks with context preservation. ![GitHub stars](https://img.shields.io/github/stars/aannoo/hcom?style=flat-square)
 - [obra/external-subagents](https://github.com/obra/external-subagents) - Run subagents as external processes with custom sandboxing. ![GitHub stars](https://img.shields.io/github/stars/obra/external-subagents?style=flat-square)
 - [GreenSheep01201/claw-empire](https://github.com/GreenSheep01201/claw-empire) - Local-first AI agent office simulator. Orchestrates CLI, OAuth, and API-connected agents as a virtual autonomous company. ![GitHub stars](https://img.shields.io/github/stars/GreenSheep01201/claw-empire?style=flat-square)
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local agent-fleet runtime for Claude Code and Codex CLI: GitHub issue claiming, isolated worktrees, launchd/systemd scheduling, Slack reporting, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime for autonomous repo teammates on Claude Code and Codex CLI: GitHub issues/specs, isolated worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ Multi-agent orchestration with `.toml` definitions. Codex supports parallel fan-
 
 ### Multi-Agent Orchestration
 
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local agent-fleet runtime for Claude Code and Codex CLI: GitHub issue claiming, isolated worktrees, launchd/systemd scheduling, Slack reporting, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
 - [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator) - Agentic orchestrator for parallel coding agents - plans tasks, spawns agents, handles CI fixes and merge conflicts autonomously. ![GitHub stars](https://img.shields.io/github/stars/ComposioHQ/agent-orchestrator?style=flat-square)
 - [mco-org/mco](https://github.com/mco-org/mco) - Neutral orchestration layer for Claude Code, Codex CLI, Gemini CLI, OpenCode, Qwen Code. Works from any IDE or shell. ![GitHub stars](https://img.shields.io/github/stars/mco-org/mco?style=flat-square)
 - [basilisk-labs/codex-swarm](https://github.com/basilisk-labs/codex-swarm) - Swarm intelligence pattern - multiple Codex agents collaborating on large refactors. ![GitHub stars](https://img.shields.io/github/stars/basilisk-labs/codex-swarm?style=flat-square)
 - [aannoo/hcom](https://github.com/aannoo/hcom) - Hierarchical agent communication framework. Agents delegate subtasks with context preservation. ![GitHub stars](https://img.shields.io/github/stars/aannoo/hcom?style=flat-square)
 - [obra/external-subagents](https://github.com/obra/external-subagents) - Run subagents as external processes with custom sandboxing. ![GitHub stars](https://img.shields.io/github/stars/obra/external-subagents?style=flat-square)
 - [GreenSheep01201/claw-empire](https://github.com/GreenSheep01201/claw-empire) - Local-first AI agent office simulator. Orchestrates CLI, OAuth, and API-connected agents as a virtual autonomous company. ![GitHub stars](https://img.shields.io/github/stars/GreenSheep01201/claw-empire?style=flat-square)
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local agent-fleet runtime for Claude Code and Codex CLI: GitHub issue claiming, isolated worktrees, launchd/systemd scheduling, Slack reporting, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Multi-agent orchestration with `.toml` definitions. Codex supports parallel fan-
 - [aannoo/hcom](https://github.com/aannoo/hcom) - Hierarchical agent communication framework. Agents delegate subtasks with context preservation. ![GitHub stars](https://img.shields.io/github/stars/aannoo/hcom?style=flat-square)
 - [obra/external-subagents](https://github.com/obra/external-subagents) - Run subagents as external processes with custom sandboxing. ![GitHub stars](https://img.shields.io/github/stars/obra/external-subagents?style=flat-square)
 - [GreenSheep01201/claw-empire](https://github.com/GreenSheep01201/claw-empire) - Local-first AI agent office simulator. Orchestrates CLI, OAuth, and API-connected agents as a virtual autonomous company. ![GitHub stars](https://img.shields.io/github/stars/GreenSheep01201/claw-empire?style=flat-square)
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime for autonomous repo teammates on Claude Code and Codex CLI: GitHub issues/specs, isolated worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex CLI runs: clean worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Multi-agent orchestration with `.toml` definitions. Codex supports parallel fan-
 
 ### Multi-Agent Orchestration
 
+- [Alfred](https://github.com/luminik-io/alfred-os) - Local agent-fleet runtime for Claude Code and Codex CLI: GitHub issue claiming, isolated worktrees, launchd/systemd scheduling, Slack reporting, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
 - [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator) - Agentic orchestrator for parallel coding agents - plans tasks, spawns agents, handles CI fixes and merge conflicts autonomously. ![GitHub stars](https://img.shields.io/github/stars/ComposioHQ/agent-orchestrator?style=flat-square)
 - [mco-org/mco](https://github.com/mco-org/mco) - Neutral orchestration layer for Claude Code, Codex CLI, Gemini CLI, OpenCode, Qwen Code. Works from any IDE or shell. ![GitHub stars](https://img.shields.io/github/stars/mco-org/mco?style=flat-square)
 - [basilisk-labs/codex-swarm](https://github.com/basilisk-labs/codex-swarm) - Swarm intelligence pattern - multiple Codex agents collaborating on large refactors. ![GitHub stars](https://img.shields.io/github/stars/basilisk-labs/codex-swarm?style=flat-square)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Multi-agent orchestration with `.toml` definitions. Codex supports parallel fan-
 - [aannoo/hcom](https://github.com/aannoo/hcom) - Hierarchical agent communication framework. Agents delegate subtasks with context preservation. ![GitHub stars](https://img.shields.io/github/stars/aannoo/hcom?style=flat-square)
 - [obra/external-subagents](https://github.com/obra/external-subagents) - Run subagents as external processes with custom sandboxing. ![GitHub stars](https://img.shields.io/github/stars/obra/external-subagents?style=flat-square)
 - [GreenSheep01201/claw-empire](https://github.com/GreenSheep01201/claw-empire) - Local-first AI agent office simulator. Orchestrates CLI, OAuth, and API-connected agents as a virtual autonomous company. ![GitHub stars](https://img.shields.io/github/stars/GreenSheep01201/claw-empire?style=flat-square)
-- [Alfred](https://github.com/luminik-io/alfred-os) - Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex CLI runs: clean worktrees, PRs, reviews, tests, Slack reports, and per-agent engine routing. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
+- [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime that turns GitHub issues into autonomous Codex CLI and Claude Code runs. Worktrees, label state, Slack reports. ![GitHub stars](https://img.shields.io/github/stars/luminik-io/alfred-os?style=flat-square)
 
 ## Skills
 


### PR DESCRIPTION
Adds Alfred to Multi-Agent Orchestration. Alfred is directly relevant to Codex CLI because it can route scheduled coding-agent jobs to Codex and Claude Code, with GitHub issue claiming, isolated worktrees, launchd/systemd scheduling, Slack reporting, and per-agent engine routing.

Source: https://github.com/luminik-io/alfred-os

Validation: git diff --check