### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [callstackincubator/agent-skills](https://github.com/callstackincubator/agent-skills) - Agent-optimized React Native skills by Callstack: best practices, optimization, upgrade workflows. ![GitHub stars](https://img.shields.io/github/stars/callstackincubator/agent-skills?style=flat-square)
 - [Bhanunamikaze/Agentic-SEO-Skill](https://github.com/Bhanunamikaze/Agentic-SEO-Skill) - LLM-first SEO analysis with 16 sub-skills, 10 specialist agents, and 33 utility scripts. ![GitHub stars](https://img.shields.io/github/stars/Bhanunamikaze/Agentic-SEO-Skill?style=flat-square)
 - [Gitmaxd/deepagents-cli-codex-skill](https://github.com/Gitmaxd/deepagents-cli-codex-skill) - Deep Agents CLI skill - scaffolds Codex skills and launches production subagent pipelines. ![GitHub stars](https://img.shields.io/github/stars/Gitmaxd/deepagents-cli-codex-skill?style=flat-square)
+- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs. ![GitHub stars](https://img.shields.io/github/stars/wordbricks/skills?style=flat-square)
 
 ### Skills Management
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [callstackincubator/agent-skills](https://github.com/callstackincubator/agent-skills) - Agent-optimized React Native skills by Callstack: best practices, optimization, upgrade workflows. ![GitHub stars](https://img.shields.io/github/stars/callstackincubator/agent-skills?style=flat-square)
 - [Bhanunamikaze/Agentic-SEO-Skill](https://github.com/Bhanunamikaze/Agentic-SEO-Skill) - LLM-first SEO analysis with 16 sub-skills, 10 specialist agents, and 33 utility scripts. ![GitHub stars](https://img.shields.io/github/stars/Bhanunamikaze/Agentic-SEO-Skill?style=flat-square)
 - [Gitmaxd/deepagents-cli-codex-skill](https://github.com/Gitmaxd/deepagents-cli-codex-skill) - Deep Agents CLI skill - scaffolds Codex skills and launches production subagent pipelines. ![GitHub stars](https://img.shields.io/github/stars/Gitmaxd/deepagents-cli-codex-skill?style=flat-square)
-- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs. ![GitHub stars](https://img.shields.io/github/stars/wordbricks/skills?style=flat-square)
+- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources. ![GitHub stars](https://img.shields.io/github/stars/wordbricks/skills?style=flat-square)
 
 ### Skills Management
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [callstackincubator/agent-skills](https://github.com/callstackincubator/agent-skills) - Agent-optimized React Native skills by Callstack: best practices, optimization, upgrade workflows. ![GitHub stars](https://img.shields.io/github/stars/callstackincubator/agent-skills?style=flat-square)
 - [Bhanunamikaze/Agentic-SEO-Skill](https://github.com/Bhanunamikaze/Agentic-SEO-Skill) - LLM-first SEO analysis with 16 sub-skills, 10 specialist agents, and 33 utility scripts. ![GitHub stars](https://img.shields.io/github/stars/Bhanunamikaze/Agentic-SEO-Skill?style=flat-square)
 - [Gitmaxd/deepagents-cli-codex-skill](https://github.com/Gitmaxd/deepagents-cli-codex-skill) - Deep Agents CLI skill - scaffolds Codex skills and launches production subagent pipelines. ![GitHub stars](https://img.shields.io/github/stars/Gitmaxd/deepagents-cli-codex-skill?style=flat-square)
-- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources. ![GitHub stars](https://img.shields.io/github/stars/wordbricks/skills?style=flat-square)
+- [OneQuery](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable queries for agents against approved data sources. ![GitHub stars](https://img.shields.io/github/stars/wordbricks/skills?style=flat-square)
 
 ### Skills Management
 


### PR DESCRIPTION
Adds OneQuery to Skills / Specialized Skills.

OneQuery is a Codex-compatible skill for safe, auditable queries for agents against approved data sources.

Guideline check:
- One sentence explaining the value.
- Star badge uses the repo style.
- Link works and no duplicate OneQuery entry was found before submission.
- Disclosure: I am affiliated with Wordbricks/OneQuery.