### PR TITLE
Add TWZRD Agent Intel - on-chain trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Codex can connect to MCP servers (as client) and expose itself as an MCP server 
 
 ### General-Purpose MCP
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring MCP server for AI agent wallets on Solana. Verify agent identity before x402 micropayments. Free tools: score_agent, preflight_check. ![](https://img.shields.io/badge/trust-scoring-blue?style=flat-square)
 - [PleasePrompto/notebooklm-mcp](https://github.com/PleasePrompto/notebooklm-mcp) - Connect Codex to NotebookLM for research-augmented coding. ![GitHub stars](https://img.shields.io/github/stars/PleasePrompto/notebooklm-mcp?style=flat-square)
 - [mrphrazer/agentic-malware-analysis](https://github.com/mrphrazer/agentic-malware-analysis) - Agentic malware analysis environment with MCP-connected disassemblers and RE tooling. ![GitHub stars](https://img.shields.io/github/stars/mrphrazer/agentic-malware-analysis?style=flat-square)
 - [Dekelelz/let-them-talk](https://github.com/Dekelelz/let-them-talk) - MCP message broker + web dashboard for inter-agent communication. Lets Codex, Claude Code, Gemini CLI talk to each other. ![GitHub stars](https://img.shields.io/github/stars/Dekelelz/let-them-talk?style=flat-square)


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the General-Purpose MCP Servers section.

TWZRD Agent Intel is an MCP server providing on-chain trust scoring for AI agent wallets on Solana. Useful for Codex users building agents that make or receive x402 micropayments — verify counterpart wallet identity before transacting.

**MCP Configuration:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Free tools:**
- `score_agent(wallet)` — Trust score + on-chain reputation for any Solana wallet
- `preflight_check(wallet)` — Validates wallet before payment acceptance
- `get_trust_receipt(wallet)` — Cryptographic on-chain trust receipt (paid, x402)