### PR TITLE
Add Lockpaw to GUI & Desktop Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Codex can connect to MCP servers (as client) and expose itself as an MCP server 
 - [Cocoanetics/CodexMonitor](https://github.com/Cocoanetics/CodexMonitor) - macOS menu bar app to list, inspect, and watch local Codex CLI sessions. Includes VS Code integration. ![GitHub stars](https://img.shields.io/github/stars/Cocoanetics/CodexMonitor?style=flat-square)
 - [ilysenko/codex-desktop-linux](https://github.com/ilysenko/codex-desktop-linux) - Automated installer to run the OpenAI Codex Desktop app on Linux. ![GitHub stars](https://img.shields.io/github/stars/ilysenko/codex-desktop-linux?style=flat-square)
 - [LZY-Ricardo/AIDevHub](https://github.com/LZY-Ricardo/AIDevHub) - Desktop app (Tauri v2 + Rust + React) for managing MCP server configs and skills of Claude Code and Codex. ![GitHub stars](https://img.shields.io/github/stars/LZY-Ricardo/AIDevHub?style=flat-square)
+- [sorkila/lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard: one hotkey covers the screen and blocks input while Codex keeps running (no sleep), and the locked screen glows when Codex's `notify` hook fires on approval requests or completion. One-command setup (`lockpaw install-hook codex`), Touch ID unlock, also works with Claude Code and Gemini CLI. ![GitHub stars](https://img.shields.io/github/stars/sorkila/lockpaw?style=flat-square)
 
 ## Session & Workflow Management
 


### PR DESCRIPTION
Adds [Lockpaw](https://github.com/sorkila/lockpaw) — a free, open-source macOS menu bar screen guard with first-class Codex CLI integration.

One hotkey covers the screen and blocks input while Codex keeps running (no sleep), and the locked screen glows + notifies when Codex's `notify` hook fires on an approval request or completion — so you can walk away without either babysitting the terminal or unlocking the machine for the agent. Setup is one command: `lockpaw install-hook codex` (it writes the `notify` entry to `config.toml`, backs up the file, and won't clobber a foreign notify handler). Touch ID unlock; also works with Claude Code and Gemini CLI.

Native Swift, ~10 MB, no analytics, MIT. Entry follows the list format with the flat-square star badge, placed in GUI & Desktop Apps alongside the other macOS menu bar apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)