### PR TITLE
Add skillet under Skills Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [jiweiyeah/Skills-Manager](https://github.com/jiweiyeah/Skills-Manager) - Cross-platform desktop app (Tauri 2.0 + React 19 + Rust) for managing skills across multiple AI tools. ![GitHub stars](https://img.shields.io/github/stars/jiweiyeah/Skills-Manager?style=flat-square)
 - [DargonLee/skill-switch](https://github.com/DargonLee/skill-switch) - Cross-platform desktop app for managing AI tool skill files - unified interface for Codex CLI, Claude Code, Gemini CLI, Cursor. ![GitHub stars](https://img.shields.io/github/stars/DargonLee/skill-switch?style=flat-square)
 - [aiskillstore/marketplace](https://github.com/aiskillstore/marketplace) - Security-audited skills marketplace. One-click install with automated security analysis. ![GitHub stars](https://img.shields.io/github/stars/aiskillstore/marketplace?style=flat-square)
+- [Brattlof/skillet](https://github.com/Brattlof/skillet) - Zero-dependency Go CLI and package manager that installs skills, slash commands, hooks, and MCP servers across Codex, Claude Code, Cursor, Gemini CLI, Copilot, and Cline. ![GitHub stars](https://img.shields.io/github/stars/Brattlof/skillet?style=flat-square)
 
 ### Domain-Specific Skills
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [jiweiyeah/Skills-Manager](https://github.com/jiweiyeah/Skills-Manager) - Cross-platform desktop app (Tauri 2.0 + React 19 + Rust) for managing skills across multiple AI tools. ![GitHub stars](https://img.shields.io/github/stars/jiweiyeah/Skills-Manager?style=flat-square)
 - [DargonLee/skill-switch](https://github.com/DargonLee/skill-switch) - Cross-platform desktop app for managing AI tool skill files - unified interface for Codex CLI, Claude Code, Gemini CLI, Cursor. ![GitHub stars](https://img.shields.io/github/stars/DargonLee/skill-switch?style=flat-square)
 - [aiskillstore/marketplace](https://github.com/aiskillstore/marketplace) - Security-audited skills marketplace. One-click install with automated security analysis. ![GitHub stars](https://img.shields.io/github/stars/aiskillstore/marketplace?style=flat-square)
-- [Brattlof/skillet](https://github.com/Brattlof/skillet) - Zero-dependency Go CLI and package manager that installs skills, slash commands, hooks, and MCP servers across Codex, Claude Code, Cursor, Gemini CLI, Copilot, and Cline. ![GitHub stars](https://img.shields.io/github/stars/Brattlof/skillet?style=flat-square)
+- [Brattlof/skillet](https://github.com/Brattlof/skillet) - Zero-dependency Go CLI / package manager that installs Agent Skills into Codex and other editors via the shared ~/.agents/skills directory, plus Claude Code commands and hooks and MCP servers for supported clients. ![GitHub stars](https://img.shields.io/github/stars/Brattlof/skillet?style=flat-square)
 
 ### Domain-Specific Skills
 


### PR DESCRIPTION
skillet is a zero-dependency Go CLI / package manager that installs skills, slash commands, hooks, and MCP servers across Codex, Claude Code, Cursor, Gemini CLI, Copilot, and Cline. Adding it under Skills Management alongside the other cross-tool skill managers.

https://github.com/Brattlof/skillet