### PR TITLE
Add BuildrAI monitoring tool resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Codex can connect to MCP servers (as client) and expose itself as an MCP server 
 - [Cocoanetics/CodexMonitor](https://github.com/Cocoanetics/CodexMonitor) - macOS menu bar app to list, inspect, and watch local Codex CLI sessions. Includes VS Code integration. ![GitHub stars](https://img.shields.io/github/stars/Cocoanetics/CodexMonitor?style=flat-square)
 - [ilysenko/codex-desktop-linux](https://github.com/ilysenko/codex-desktop-linux) - Automated installer to run the OpenAI Codex Desktop app on Linux. ![GitHub stars](https://img.shields.io/github/stars/ilysenko/codex-desktop-linux?style=flat-square)
 - [LZY-Ricardo/AIDevHub](https://github.com/LZY-Ricardo/AIDevHub) - Desktop app (Tauri v2 + Rust + React) for managing MCP server configs and skills of Claude Code and Codex. ![GitHub stars](https://img.shields.io/github/stars/LZY-Ricardo/AIDevHub?style=flat-square)
-- [michaelversus/BuildrAIApp](https://github.com/michaelversus/BuildrAIApp) - Desktop app that helps you inspect and share your AI Sessions. Use it to improve your workflow. Supports Evals and secrets redaction.
+- [michaelversus/BuildrAIApp](https://github.com/michaelversus/BuildrAIApp) - Desktop app that helps you inspect and share your AI Sessions. Use it to improve your workflow. Supports Evals and secrets redaction. ![Github_stars]
 
 ## Session & Workflow Management
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Codex can connect to MCP servers (as client) and expose itself as an MCP server 
 - [Cocoanetics/CodexMonitor](https://github.com/Cocoanetics/CodexMonitor) - macOS menu bar app to list, inspect, and watch local Codex CLI sessions. Includes VS Code integration. ![GitHub stars](https://img.shields.io/github/stars/Cocoanetics/CodexMonitor?style=flat-square)
 - [ilysenko/codex-desktop-linux](https://github.com/ilysenko/codex-desktop-linux) - Automated installer to run the OpenAI Codex Desktop app on Linux. ![GitHub stars](https://img.shields.io/github/stars/ilysenko/codex-desktop-linux?style=flat-square)
 - [LZY-Ricardo/AIDevHub](https://github.com/LZY-Ricardo/AIDevHub) - Desktop app (Tauri v2 + Rust + React) for managing MCP server configs and skills of Claude Code and Codex. ![GitHub stars](https://img.shields.io/github/stars/LZY-Ricardo/AIDevHub?style=flat-square)
+- [michaelversus/BuildrAIApp](https://github.com/michaelversus/BuildrAIApp) - Desktop app that helps you inspect and share your AI Sessions. Use it to improve your workflow. Supports Evals and secrets redaction.
 
 ## Session & Workflow Management
 


### PR DESCRIPTION
Hi, I would like to suggest adding BuildrAI to the GUI & Desktop Apps section.

Suggested entry:
[BuildrAI](https://github.com/michaelversus/BuildrAIApp)

Why it fits:

It is a small macOS app that can give valuable insights for all your local AI Sessions and make them shareable.
Valuable metrics
Prompts and Session evaluations
Token Consumption
Tool Usages
Redaction for secrets