### PR TITLE
Add codex-gate to Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ User-defined shell scripts that run at specific points in the agentic loop. Requ
 - [shanraisshan/codex-cli-hooks](https://github.com/shanraisshan/codex-cli-hooks) - Starter hooks collection: pre-commit validation, cost tracking, notification triggers. ![GitHub stars](https://img.shields.io/github/stars/shanraisshan/codex-cli-hooks?style=flat-square)
 - [liewcf/codex-notify-macos](https://github.com/liewcf/codex-notify-macos) - macOS notification hook - get alerted when long-running tasks complete. ![GitHub stars](https://img.shields.io/github/stars/liewcf/codex-notify-macos?style=flat-square)
 - [vcz-Gray/loophaus](https://github.com/vcz-Gray/loophaus) - Cross-platform iterative development loops via Stop hooks. ![GitHub stars](https://img.shields.io/github/stars/vcz-Gray/loophaus?style=flat-square)
+- [PMWang/codex-gate](https://github.com/PMWang/codex-gate) - Quality gate as a Stop hook: blocks turns whose claims don't match the diff, re-runs claimed tests, enforces AGENTS.md rules. Also ships a GitHub Action for gating agent PRs. ![GitHub stars](https://img.shields.io/github/stars/PMWang/codex-gate?style=flat-square)
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [codex-gate](https://github.com/PMWang/codex-gate) to the Hooks section.

It's a quality gate for agent output that installs as a Codex `Stop` hook (`codex-gate install --codex-hook`): each turn is checked so that the description matches the diff, claimed tests are actually re-run, and machine-checkable AGENTS.md rules are enforced. Warn-level churn detection, zero-dependency core, MIT. It also ships a composite GitHub Action so maintainers can require the same checks as a status check on agent PRs.

Placed after loophaus at the end of the Hooks section, following the existing entry format (stars badge included).