### PR TITLE
Add Codex WezTerm Notify to Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ User-defined shell scripts that run at specific points in the agentic loop. Requ
 - [PeonPing/peon-ping](https://github.com/PeonPing/peon-ping) - Warcraft III Peon voice notifications for Codex, Claude Code, and IDEs. Stop babysitting your terminal. ![GitHub stars](https://img.shields.io/github/stars/PeonPing/peon-ping?style=flat-square)
 - [shanraisshan/codex-cli-hooks](https://github.com/shanraisshan/codex-cli-hooks) - Starter hooks collection: pre-commit validation, cost tracking, notification triggers. ![GitHub stars](https://img.shields.io/github/stars/shanraisshan/codex-cli-hooks?style=flat-square)
 - [liewcf/codex-notify-macos](https://github.com/liewcf/codex-notify-macos) - macOS notification hook - get alerted when long-running tasks complete. ![GitHub stars](https://img.shields.io/github/stars/liewcf/codex-notify-macos?style=flat-square)
+- [Tomauskasz/codex-wezterm-notify](https://github.com/Tomauskasz/codex-wezterm-notify) - Windows notifications for Codex terminals; WezTerm adds click-to-return to the exact pane. ![GitHub stars](https://img.shields.io/github/stars/Tomauskasz/codex-wezterm-notify?style=flat-square)
 - [vcz-Gray/loophaus](https://github.com/vcz-Gray/loophaus) - Cross-platform iterative development loops via Stop hooks. ![GitHub stars](https://img.shields.io/github/stars/vcz-Gray/loophaus?style=flat-square)
 
 ## MCP Servers

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ User-defined shell scripts that run at specific points in the agentic loop. Requ
 - [PeonPing/peon-ping](https://github.com/PeonPing/peon-ping) - Warcraft III Peon voice notifications for Codex, Claude Code, and IDEs. Stop babysitting your terminal. ![GitHub stars](https://img.shields.io/github/stars/PeonPing/peon-ping?style=flat-square)
 - [shanraisshan/codex-cli-hooks](https://github.com/shanraisshan/codex-cli-hooks) - Starter hooks collection: pre-commit validation, cost tracking, notification triggers. ![GitHub stars](https://img.shields.io/github/stars/shanraisshan/codex-cli-hooks?style=flat-square)
 - [liewcf/codex-notify-macos](https://github.com/liewcf/codex-notify-macos) - macOS notification hook - get alerted when long-running tasks complete. ![GitHub stars](https://img.shields.io/github/stars/liewcf/codex-notify-macos?style=flat-square)
-- [Tomauskasz/codex-wezterm-notify](https://github.com/Tomauskasz/codex-wezterm-notify) - Windows notifications for Codex terminals; WezTerm adds click-to-return to the exact pane. ![GitHub stars](https://img.shields.io/github/stars/Tomauskasz/codex-wezterm-notify?style=flat-square)
+- [Tomauskasz/codex-wezterm-notify](https://github.com/Tomauskasz/codex-wezterm-notify) - Windows notifications for Codex and Claude Code; WezTerm adds click-to-return to the exact pane. ![GitHub stars](https://img.shields.io/github/stars/Tomauskasz/codex-wezterm-notify?style=flat-square)
 - [vcz-Gray/loophaus](https://github.com/vcz-Gray/loophaus) - Cross-platform iterative development loops via Stop hooks. ![GitHub stars](https://img.shields.io/github/stars/vcz-Gray/loophaus?style=flat-square)
 
 ## MCP Servers


### PR DESCRIPTION
## Summary

Adds Codex WezTerm Notify to the Hooks section.

The plugin shows completion and approval notifications with Unicode-safe response previews and sound from native Windows Codex terminals. WezTerm additionally supports click-to-return to the exact originating pane; in other terminals, clicking dismisses the notification. The shared renderer also supports equivalent Claude Code lifecycle hooks.

## Quality checks

- Public MIT-licensed repository with install, update, uninstall, privacy, limitations, and Claude Code setup documentation
- Released as [v0.3.0](https://github.com/Tomauskasz/codex-wezterm-notify/releases/tag/v0.3.0)
- Raw UTF-8, generic-terminal, WezTerm, Codex, and Claude payload coverage
- Windows GitHub Actions passed for v0.3.0 commit `91bf288`
- `awesome-lint` reports no content errors; its two repository-topic checks cannot pass against the contributor fork because those topics belong to the upstream repository
- Uses current Codex lifecycle hooks rather than the legacy API
