### PR TITLE
Add Suede Creator Skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) - Performance optimization system with 36 agents and 147 skills. Has `/codex-setup` command for Codex CLI. ![GitHub stars](https://img.shields.io/github/stars/affaan-m/everything-claude-code?style=flat-square)
 - [simota/agent-skills](https://github.com/simota/agent-skills) - 100+ specialized AI agent skills for Claude Code / Codex CLI / Gemini CLI - dev, security, design, FinOps, compliance, testing. ![GitHub stars](https://img.shields.io/github/stars/simota/agent-skills?style=flat-square)
 - [gmh5225/awesome-skills](https://github.com/gmh5225/awesome-skills) - Curated list of agent skills and tools for Claude Code, Codex, Gemini CLI, GitHub Copilot, and more. ![GitHub stars](https://img.shields.io/github/stars/gmh5225/awesome-skills?style=flat-square)
-- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - 71 MIT-licensed Codex and Claude Code skills for multi-agent orchestration, Codex worker fleets, code review and ship gates, AI evaluation, product, design, and growth workflows. ![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - MIT-licensed Codex and Claude Code skills for multi-agent orchestration, Codex worker fleets, code review and ship gates, AI evaluation, product, design, and growth workflows. ![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
 
 ### Specialized Skills
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) - Performance optimization system with 36 agents and 147 skills. Has `/codex-setup` command for Codex CLI. ![GitHub stars](https://img.shields.io/github/stars/affaan-m/everything-claude-code?style=flat-square)
 - [simota/agent-skills](https://github.com/simota/agent-skills) - 100+ specialized AI agent skills for Claude Code / Codex CLI / Gemini CLI - dev, security, design, FinOps, compliance, testing. ![GitHub stars](https://img.shields.io/github/stars/simota/agent-skills?style=flat-square)
 - [gmh5225/awesome-skills](https://github.com/gmh5225/awesome-skills) - Curated list of agent skills and tools for Claude Code, Codex, Gemini CLI, GitHub Copilot, and more. ![GitHub stars](https://img.shields.io/github/stars/gmh5225/awesome-skills?style=flat-square)
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - 67 MIT-licensed Codex and Claude Code skills for multi-agent orchestration, Codex worker fleets, code review and ship gates, AI evaluation, product, design, and growth workflows. ![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
 
 ### Specialized Skills
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Reusable instruction bundles in `SKILL.md` format. Place in `~/.codex/skills/` (
 - [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) - Performance optimization system with 36 agents and 147 skills. Has `/codex-setup` command for Codex CLI. ![GitHub stars](https://img.shields.io/github/stars/affaan-m/everything-claude-code?style=flat-square)
 - [simota/agent-skills](https://github.com/simota/agent-skills) - 100+ specialized AI agent skills for Claude Code / Codex CLI / Gemini CLI - dev, security, design, FinOps, compliance, testing. ![GitHub stars](https://img.shields.io/github/stars/simota/agent-skills?style=flat-square)
 - [gmh5225/awesome-skills](https://github.com/gmh5225/awesome-skills) - Curated list of agent skills and tools for Claude Code, Codex, Gemini CLI, GitHub Copilot, and more. ![GitHub stars](https://img.shields.io/github/stars/gmh5225/awesome-skills?style=flat-square)
-- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - 67 MIT-licensed Codex and Claude Code skills for multi-agent orchestration, Codex worker fleets, code review and ship gates, AI evaluation, product, design, and growth workflows. ![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - 71 MIT-licensed Codex and Claude Code skills for multi-agent orchestration, Codex worker fleets, code review and ship gates, AI evaluation, product, design, and growth workflows. ![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
 
 ### Specialized Skills
 


### PR DESCRIPTION
# Summary

- Add Suede Creator Skills to the Codex CLI skills collections.
- Describe the verified 71-skill, MIT-licensed collection and include the required live star badge.

# Why

The collection is directly installable in Codex, actively maintained, and combines orchestration, review, evaluation, product, design, and growth workflows in one documented pack.

# Testing

- Ran `git diff --check`.
- Verified the public repository and live star badge resolve.
- Verified the source reports 71 skill folders and an MIT license.

# Scope

Documentation only; no runtime behavior changes.

# Risks

The public skill count can change over time. The description reflects the source repository on 2026-08-12.